### PR TITLE
Rename "params" to "query_params"

### DIFF
--- a/lib/mithril_api/logger_json.ex
+++ b/lib/mithril_api/logger_json.ex
@@ -76,7 +76,7 @@ defmodule Ecto.LoggerJSON do
           "query" => query,
           "query_time" => query_time,
           "queue_time" => queue_time,
-          "params" => Enum.map(params, &param_to_string/1)
+          "query_params" => Enum.map(params, &param_to_string/1)
         }
         |> Poison.encode!()
       end)


### PR DESCRIPTION
Both kinds of our phoenix logs, both ecto and [plug](https://github.com/bleacherreport/plug_logger_json/blob/master/lib/plug/logger_json.ex#L172), have "params" field. In case of plug its a json object, in case of ecto - it's a string. This confuses fluentd, as it cannot properly logs from plug.